### PR TITLE
Feat/build memory address

### DIFF
--- a/prototype.txt
+++ b/prototype.txt
@@ -13,7 +13,6 @@ copy	Carr	Acc
 adcp	Carr	Bacc
 
 /// storing values
-str		x		Acc
-str		y		Bacc
-str		z		Carr
-
+str		0h		Acc
+str		1h		Bacc
+str		2h		Carr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,10 @@ pub struct MemoryAddress {
 impl MemoryAddress {
     pub fn build(param: &str) -> Result<MemoryAddress, String> {
         Immediate::build(param)
-            .and_then(|immediate| {
-                Ok(MemoryAddress {
-                    address: immediate.literal,
-                })
+            .map(|immediate| MemoryAddress {
+                address: immediate.literal,
             })
-            .or_else(|_| Err(format!("Invalid memory address: {param}")))
+            .map_err(|_| format!("Invalid memory address: {param}"))
     }
 }
 
@@ -75,7 +73,7 @@ pub struct Immediate {
 impl Immediate {
     pub fn build(param: &str) -> Result<Immediate, String> {
         let literal = if param.ends_with('h') {
-            u8::from_str_radix(&param[..param.len() - 1], 16).map_err(|e| {
+            u8::from_str_radix(param.strip_suffix('h').unwrap(), 16).map_err(|e| {
                 format!("Invalid hexadecimal immediate literal: {param}, error: {e}")
             })?
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,13 @@ pub struct MemoryAddress {
 
 impl MemoryAddress {
     pub fn build(param: &str) -> Result<MemoryAddress, String> {
-        match param {
-            _ => return Err(format!("Invalid memory address: {param}")),
-        };
+        Immediate::build(param)
+            .and_then(|immediate| {
+                Ok(MemoryAddress {
+                    address: immediate.literal,
+                })
+            })
+            .or_else(|_| Err(format!("Invalid memory address: {param}")))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
-use std::error::Error;
-use std::env;
-use std::fs::read_to_string;
 use rasm::*;
+use std::env;
+use std::error::Error;
+use std::fs::read_to_string;
 
 fn main() -> Result<(), Box<dyn Error>> {
-
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
@@ -16,22 +15,20 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let contents = read_to_string(file_path)?;
 
-    let lines: Vec<&str> = 
-        contents
+    let lines: Vec<&str> = contents
         .lines()
-        .filter(|line| *line != "")
+        .filter(|line| !line.is_empty())
         .filter(|line| line.get(..3).unwrap() != "///")
         .collect();
 
-    // let directives: Vec<&str> = 
+    // let directives: Vec<&str> =
     //     lines
     //     .clone()
     //     .into_iter()
     //     .filter(|line| line.get(..1).unwrap() == "!")
     //     .collect();
 
-    let meaningful_lines: Vec<Vec<&str>> = 
-        lines
+    let meaningful_lines: Vec<Vec<&str>> = lines
         .into_iter()
         .filter(|line| line.get(..1).unwrap() != "!")
         .map(|line| line.split_whitespace().collect())
@@ -39,16 +36,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("{meaningful_lines:#?}");
 
-
-    let instructions: Vec<Instruction> = 
-        meaningful_lines
+    let instructions: Vec<Instruction> = meaningful_lines
         .into_iter()
         .map(Instruction::build)
         .collect::<Result<Vec<Instruction>, _>>()?;
 
     println!("{instructions:#?}");
 
-
     Ok(())
 }
-


### PR DESCRIPTION
Uses the existing `Immediate::build` method so that memory addresses have the same (and potentially more) validations as immediate values