### PR TITLE
refactor/main: move overroot declaration to `lib.rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod overroot;
+
+pub use overroot::Overroot;
+
 #[derive(Debug)]
 pub enum Instruction {
     Adcp(Register, Register),      // Add copying

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-mod overroot;
-
 use std::env;
 use std::error::Error;
 use std::fs::read_to_string;
+
+use rasm::Overroot;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .filter(|line| !line.is_empty() && line.get(..3) != Some("///"))
         .collect();
 
-    let mut overroot = overroot::Overroot::new();
+    let mut overroot = Overroot::new();
 
     let replaced_lines = overroot.expand_lines(&lines)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .filter(|line| !line.is_empty() && line.get(..3) != Some("///"))
         .collect();
 
-    let mut overroot = Overroot::new();
+    let mut overroot = Overroot::default();
 
     let replaced_lines = overroot.expand_lines(&lines)?;
 

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -1,16 +1,11 @@
 use std::collections::HashMap;
 
+#[derive(Default)]
 pub struct Overroot {
     constants: HashMap<String, String>,
 }
 
 impl Overroot {
-    pub fn new() -> Self {
-        Self {
-            constants: HashMap::new(),
-        }
-    }
-
     pub fn expand_lines(&mut self, lines: &[&str]) -> Result<Vec<Vec<String>>, String> {
         self.parse_constants(lines)?;
 


### PR DESCRIPTION
move overroot declaration to `lib.rs` instead of `main.rs` itself improving separation of concerns