### PR TITLE
Feature: add leap operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-target/
+.idea/
 .zed/
+target/
 *.brx
 *.hex

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: run less
+
+run:
+	cargo run prototype.rasm
+
+
+less:
+	cargo run prototype.rasm 2>&1 | less -R

--- a/prototype.rasm
+++ b/prototype.rasm
@@ -1,35 +1,22 @@
-x := 0h
-y := 1h
+a := 0h
+b := 1h
 z := 2h
 
-R := 52h
-A := 41h
-S := 53h
-M := 4Dh
+init    Acc     3
+init    Bacc    254
+copy    Carr    Acc
+adcp    Carr    Bacc
 
-/// let byte x = 10
-init	Acc		10
+/// wz      Carr    then
 
-/// let byte y = 3
-init	Bacc	3
+/// else case
+init    Datt    2
+/// lp              endif
 
-/// ley byte z = x + y
-copy	Carr	Acc
-adcp	Carr	Bacc
+then::
+  init    Datt    1
 
-/// storing values
-str		x		Acc
-str		y		Bacc
-str		z		Carr
-
-init    Acc     R
-str     3h      Acc
-
-init    Acc     A
-str     4h      Acc
-
-init    Acc     S
-str     5h      Acc
-
-init    Acc     M
-str     6h      Acc
+endif::
+  str     a       Acc
+  str     b       Bacc
+  str     z       Datt

--- a/prototype.rasm
+++ b/prototype.rasm
@@ -11,7 +11,7 @@ adcp    Carr    Bacc
 
 /// else case
 init    Datt    2
-/// lp              endif
+lp              endif
 
 then::
   init    Datt    1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ pub enum Instruction {
 }
 
 impl Instruction {
-    pub fn build(line: Vec<&str>) -> Result<Instruction, String> {
+    pub fn build(line: &str) -> Result<Instruction, String> {
+        let line: Vec<&str> = line.split_whitespace().collect();
+
         let operation = line[0];
         let param1 = line[1];
         let param2 = line[2];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub enum Instruction {
     Init(Register, Immediate),     // Initialize
     Load(Register, MemoryAddress), // Load
     Str(MemoryAddress, Register),  // Store
+    Leap(Label),                   // Leap
 }
 
 impl Instruction {
@@ -19,17 +20,26 @@ impl Instruction {
 
         let operation = line[0];
         let param1 = line[1];
-        let param2 = line[2];
+        let param2 = line.get(2);
 
-        let inst = match operation {
-            "init" => Self::Init(Register::build(param1)?, Immediate::build(param2)?),
-            "copy" => Self::Copy(Register::build(param1)?, Register::build(param2)?),
-            "adcp" => Self::Adcp(Register::build(param1)?, Register::build(param2)?),
-            "str" => Self::Str(MemoryAddress::build(param1)?, Register::build(param2)?),
-            _ => return Err(format!("Invalid operation: {operation}")),
-        };
+        Ok(if let Some(param2) = param2 {
+            match operation {
+                "init" => Self::Init(Register::build(param1)?, Immediate::build(param2)?),
+                "copy" => Self::Copy(Register::build(param1)?, Register::build(param2)?),
+                "adcp" => Self::Adcp(Register::build(param1)?, Register::build(param2)?),
+                "str" => Self::Str(MemoryAddress::build(param1)?, Register::build(param2)?),
+                _ => return Err(format!("Invalid operation: {operation}")),
+            }
+        } else {
+            match operation {
+                "lp" => {
+                    let label_name = param1.to_string() + "::";
 
-        Ok(inst)
+                    Self::Leap(Label::build(label_name.as_str(), None)?)
+                }
+                _ => return Err(format!("Invalid operation: {operation}")),
+            }
+        })
     }
 
     pub fn encode(&self) -> Result<String, String> {
@@ -38,6 +48,7 @@ impl Instruction {
             Self::Copy(register1, register2) => [10, register1.reg_id, register2.reg_id],
             Self::Adcp(register1, register2) => [11, register1.reg_id, register2.reg_id],
             Self::Str(memaddr, register) => [7, memaddr.address, register.reg_id],
+            Self::Leap(label) => [0x2, 0, label.position.unwrap()],
             _ => {
                 return Err(format!("Operation {:?} not implemented yet!", self));
             }
@@ -71,17 +82,20 @@ impl Register {
 }
 
 #[derive(Debug)]
-pub struct MemoryAddress {
-    address: u8,
+pub struct Label {
+    name: String,
+    position: Option<u8>,
 }
 
-impl MemoryAddress {
-    pub fn build(param: &str) -> Result<MemoryAddress, String> {
-        Immediate::build(param)
-            .map(|immediate| MemoryAddress {
-                address: immediate.literal,
-            })
-            .map_err(|_| format!("Invalid memory address: {param}"))
+impl Label {
+    pub fn build(param: &str, position: Option<u8>) -> Result<Label, String> {
+        match param.strip_suffix("::") {
+            Some(name) => Ok(Self {
+                name: name.to_string(),
+                position,
+            }),
+            None => Err(format!("Invalid syntax for label: '{param}'")),
+        }
     }
 }
 
@@ -103,5 +117,20 @@ impl Immediate {
         };
 
         Ok(Immediate { literal })
+    }
+}
+
+#[derive(Debug)]
+pub struct MemoryAddress {
+    address: u8,
+}
+
+impl MemoryAddress {
+    pub fn build(param: &str) -> Result<MemoryAddress, String> {
+        Immediate::build(param)
+            .map(|immediate| MemoryAddress {
+                address: immediate.literal,
+            })
+            .map_err(|_| format!("Invalid memory address: {param}"))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,8 @@ impl Instruction {
         } else {
             match operation {
                 "lp" => {
-                    let label_name = param1.to_string() + "::";
-
-                    Self::Leap(Label::build(label_name.as_str(), None)?)
+                    let label_name = format!("{}::", param1);
+                    Self::Leap(Label::build(&label_name, None)?)
                 }
                 _ => return Err(format!("Invalid operation: {operation}")),
             }
@@ -48,7 +47,7 @@ impl Instruction {
             Self::Copy(register1, register2) => [10, register1.reg_id, register2.reg_id],
             Self::Adcp(register1, register2) => [11, register1.reg_id, register2.reg_id],
             Self::Str(memaddr, register) => [7, memaddr.address, register.reg_id],
-            Self::Leap(label) => [0x2, 0, label.position.unwrap()],
+            Self::Leap(label) => [0x02, 0x00, label.position.unwrap()],
             _ => {
                 return Err(format!("Operation {:?} not implemented yet!", self));
             }
@@ -90,11 +89,17 @@ pub struct Label {
 impl Label {
     pub fn build(param: &str, position: Option<u8>) -> Result<Label, String> {
         match param.strip_suffix("::") {
-            Some(name) => Ok(Self {
-                name: name.to_string(),
-                position,
-            }),
-            None => Err(format!("Invalid syntax for label: '{param}'")),
+            Some(name) => {
+                if name.is_empty() {
+                    return Err("Label name cannot be empty".to_string());
+                }
+
+                Ok(Self {
+                    name: name.to_string(),
+                    position,
+                })
+            }
+            None => Err(format!("Label must end with '::' but got: '{param}'")),
         }
     }
 }

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -1,65 +1,89 @@
 use std::collections::HashMap;
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct Overroot {
     constants: HashMap<String, String>,
+    labels: HashMap<String, usize>,
+    instructions: Vec<crate::Instruction>,
+}
+
+impl TryFrom<String> for Overroot {
+    type Error = String;
+
+    fn try_from(contents: String) -> Result<Self, Self::Error> {
+        let mut overroot = Self {
+            constants: HashMap::new(),
+            labels: HashMap::new(),
+            instructions: Vec::new(),
+        };
+
+        for line in contents.lines() {
+            let line_is_comment = line.get(..3) == Some("///");
+
+            if line.is_empty() || line_is_comment {
+                continue;
+            }
+
+            if line.contains("::") {
+                overroot.insert_label(line);
+            } else if line.contains(":=") {
+                overroot.insert_constant(line)?;
+            } else {
+                overroot.push_instruction(line)?;
+            }
+        }
+
+        Ok(overroot)
+    }
 }
 
 impl Overroot {
-    pub fn expand_lines(&mut self, lines: &[&str]) -> Result<Vec<Vec<String>>, String> {
-        self.parse_constants(lines)?;
+    fn insert_constant(&mut self, line: &str) -> Result<(), String> {
+        let parts: Vec<&str> = line.split(":=").collect();
 
-        // Extract instruction lines
-        let meaningful_lines: Vec<Vec<&str>> = lines
-            .iter()
-            .copied()
-            .filter(|line| !line.contains(":="))
-            .map(|line| line.split_whitespace().collect())
-            .collect();
+        if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+            return Err(format!("Invalid constant format: `{line}`"));
+        }
 
-        // Replace constant names with their defined values
-        Ok(meaningful_lines
-            .into_iter()
-            .map(|line| {
-                line.into_iter()
-                    .map(|token| {
-                        // Check if token is defined as a constant and replace it
-                        // If not found, keep the original token
-                        if self.constants.contains_key(token) {
-                            self.constants[token].clone()
-                        } else {
-                            token.to_string()
-                        }
-                    })
-                    .collect()
-            })
-            .collect())
+        let name = parts[0].trim().to_string();
+        let value = parts[1].trim().to_string();
+
+        self.constants.insert(name, value);
+
+        Ok(())
     }
 
-    // Extract constant lines
-    pub fn parse_constants(&mut self, lines: &[&str]) -> Result<(), String> {
-        lines
-            .iter()
-            .copied()
-            .filter(|line| line.contains(":="))
-            .try_for_each(|line| {
-                // Parse constants from directives
-                // Format: !CONSTANT_NAME: value
-                // Example: !MY_REG: A, !MEMORY_ADDR: 20h, !CONSTANT: 42
-                let parts: Vec<&str> = line.split(":=").collect();
-
-                if parts.len() != 2 {
-                    return Err(format!("Invalid constant format: {line}"));
+    fn push_instruction(&mut self, line: &str) -> Result<(), String> {
+        let instruction_line = line
+            .split_whitespace()
+            .map(|token| {
+                // Check if token is defined as a constant and replace it
+                // If not found, keep the original token
+                if self.constants.contains_key(token) {
+                    self.constants[token].as_str()
+                } else {
+                    token
                 }
-
-                let name = parts[0].trim().to_string();
-                let value = parts[1].trim().to_string();
-
-                // println!("name: {name:#?}\nvalue: {value:#?}");
-
-                self.constants.insert(name, value);
-
-                Ok(())
             })
+            .collect::<Vec<&str>>()
+            .join(" ");
+
+        let instruction = crate::Instruction::build(instruction_line.as_str())?;
+
+        self.instructions.push(instruction);
+
+        Ok(())
+    }
+
+    fn insert_label(&mut self, line: &str) {
+        self.labels
+            .insert(line.to_string(), self.instructions.len());
+    }
+
+    pub fn encode(self) -> Result<Vec<String>, String> {
+        self.instructions
+            .into_iter()
+            .map(|instruction| instruction.encode())
+            .collect()
     }
 }

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct Overroot {
     constants: HashMap<String, String>,
-    labels: HashMap<String, usize>,
+    labels: HashMap<String, u8>,
+    // instructions: HashMap<String, crate::Instruction>,
     instructions: Vec<crate::Instruction>,
 }
 
@@ -76,13 +77,30 @@ impl Overroot {
     }
 
     fn insert_label(&mut self, line: &str) {
-        self.labels
-            .insert(line.to_string(), self.instructions.len());
+        let label_index = self.instructions.len() as u8;
+        let label_name = line.strip_suffix("::").unwrap().to_string();
+
+        self.labels.insert(label_name.clone(), label_index);
+
+        for instruction in self.instructions.iter_mut() {
+            if let crate::Instruction::Leap(crate::Label {
+                name,
+                position: None,
+            }) = instruction
+            {
+                let a = self.labels.get(&name.to_owned());
+
+                *instruction = crate::Instruction::Leap(crate::Label {
+                    name: name.to_string(),
+                    position: a.copied(),
+                });
+            };
+        }
     }
 
     pub fn encode(self) -> Result<Vec<String>, String> {
         self.instructions
-            .into_iter()
+            .iter()
             .map(|instruction| instruction.encode())
             .collect()
     }

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 pub struct Overroot {
     constants: HashMap<String, String>,
     labels: HashMap<String, u8>,
-    // instructions: HashMap<String, crate::Instruction>,
     instructions: Vec<crate::Instruction>,
 }
 
@@ -88,12 +87,10 @@ impl Overroot {
                 position: None,
             }) = instruction
             {
-                let a = self.labels.get(&name.to_owned());
+                let name = name.to_string();
+                let position = self.labels.get(&name).copied();
 
-                *instruction = crate::Instruction::Leap(crate::Label {
-                    name: name.to_string(),
-                    position: a.copied(),
-                });
+                *instruction = crate::Instruction::Leap(crate::Label { name, position });
             };
         }
     }


### PR DESCRIPTION
add support to leap operation, that means we now have unconditional jumps in rasm

```
a := 0h
b := 1h
z := 2h

init    Acc     3
init    Bacc    254
copy    Carr    Acc
adcp    Carr    Bacc

/// wz      Carr    then

/// else case
init    Datt    2
lp              endif

then::
  init    Datt    1

endif::
  str     a       Acc
  str     b       Bacc
  str     z       Datt
```

In this simple example, we skip the `init Datt 1` instruction because the previous instruction jumps to the next label, reaching the desired label (endif).

TODO: conditional jumps (wz and wn), so we will complete the flow instructions implementation