### PR TITLE
Fix(leap): backward jumps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ impl Instruction {
             Self::Add(r1, r2, r3) => 0x0000 | r1.bits() << 8 | r2.bits() << 4 | r3.bits(),
             Self::Str(addr, reg) => 0xC000 | addr.bits() << 4 | reg.bits(),
             Self::Leap(label) => 0x7000 | label.bits()?,
-            _ => return Err(format!("Operation {:?} not implemented yet!", self)),
         };
 
         Ok(format!("{word:04X}"))

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -33,6 +33,28 @@ impl TryFrom<String> for Overroot {
             }
         }
 
+        let unresolved: Vec<(usize, String)> = overroot.instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, inst)| {
+                if let crate::Instruction::Leap(crate::Label { name, position: None }) = inst {
+                    Some((i, name.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for (i, name) in unresolved {
+            let position = overroot.labels.get(&name)
+                .copied()
+                .ok_or_else(|| format!("Label '{name}' not found"))?;
+
+            overroot.instructions[i] = crate::Instruction::Leap(
+                crate::Label { name, position: Some(position) }
+            );
+        }
+
         Ok(overroot)
     }
 }
@@ -84,20 +106,7 @@ impl Overroot {
 
         let label_name = line.strip_suffix("::").unwrap().to_string();
 
-        self.labels.insert(label_name.clone(), label_index);
-
-        for instruction in self.instructions.iter_mut() {
-            if let crate::Instruction::Leap(crate::Label {
-                name,
-                position: None,
-            }) = instruction
-            {
-                let name = name.to_string();
-                let position = self.labels.get(&name).copied();
-
-                *instruction = crate::Instruction::Leap(crate::Label { name, position });
-            };
-        }
+        self.labels.insert(label_name, label_index);
 
         Ok(())
     }

--- a/src/overroot.rs
+++ b/src/overroot.rs
@@ -37,7 +37,7 @@ impl TryFrom<String> for Overroot {
             .iter()
             .enumerate()
             .filter_map(|(i, inst)| {
-                if let crate::Instruction::Leap(crate::Label { name, position: None }) = inst {
+                if let crate::Instruction::Leap(crate::Label { name, position: _ }) = inst {
                     Some((i, name.clone()))
                 } else {
                     None


### PR DESCRIPTION
The previous implementation of `leap` worked for forward jumps, but failed when any backward jump was performed, so now a loop has been added to iterate through the instructions at the end of the `try_from` block, which resolves all labels to their respective positions.